### PR TITLE
scripts: do not restart kubelet on install/uninstall

### DIFF
--- a/scripts/container-engine-for-cc-deploy.sh
+++ b/scripts/container-engine-for-cc-deploy.sh
@@ -57,8 +57,6 @@ function restart_systemd_service() {
 	systemctl daemon-reload
 	echo "Restarting ${container_engine}"
 	systemctl restart "${container_engine}"
-	echo "Restarting kubelet"
-	systemctl restart kubelet
 }
 
 label_node() {


### PR DESCRIPTION
On commit d5ef5600e03c it was added in the instruction to restart kubelet on both post-install and post-uninstall. That seems to have caused the post-uninstall daemon to get stuck on termination state. From what I understood, once restarted, kubelet goes into a state where it cannot umount the volumes of the post-uninstall daemon, hence the pod keeps terminating forever.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>